### PR TITLE
Use standard react-scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,18 +12,18 @@
     "react": "^16.8.2",
     "react-dom": "^16.8.2",
     "react-redux": "^6.0.1",
-    "react-scripts-ts": "3.1.0",
+    "react-scripts": "2.1.8",
     "redux": "^4.0.1",
     "socket.io": "^2.2.0",
     "socket.io-client": "^2.2.0"
   },
   "scripts": {
-    "start": "react-scripts-ts start",
-    "build": "react-scripts-ts build",
+    "start": "react-scripts start",
+    "build": "react-scripts build",
     "start-server": "node build/server.js",
     "build-server": "tsc --project tsconfig.server.json --jsx react",
-    "test": "react-scripts-ts test --env=jsdom",
-    "eject": "react-scripts-ts eject"
+    "test": "react-scripts test --env=jsdom",
+    "eject": "react-scripts eject"
   },
   "jest": {
     "snapshotSerializers": [
@@ -40,8 +40,13 @@
     "enzyme": "^3.9.0",
     "enzyme-adapter-react-16": "^1.10.0",
     "enzyme-to-json": "^3.3.5",
-    "jest": "^24.1.0",
     "react-test-renderer": "^16.8.3",
     "typescript": "^3.3.3"
-  }
+  },
+  "browserslist": [
+    ">0.2%",
+    "not dead",
+    "not ie <= 11",
+    "not op_mini all"
+  ]
 }

--- a/src/containers/CivPanel.tsx
+++ b/src/containers/CivPanel.tsx
@@ -9,7 +9,7 @@ import * as actions from "../actions";
 
 export function mapStateToProps(state: IStoreState) {
     let triggerAction: ActionType = ActionType.NOTHING;
-    if (state.nextAction < state.preset.turns.length) {
+    if (state.preset && state.nextAction < state.preset.turns.length) {
         triggerAction = actionTypeFromAction(state.preset.turns[state.nextAction].action);
     }
     return {

--- a/src/containers/Draft.tsx
+++ b/src/containers/Draft.tsx
@@ -3,6 +3,7 @@ import * as actions from '../actions/';
 import {IStoreState} from '../types';
 import {connect} from 'react-redux';
 import {Dispatch} from 'redux';
+import Preset from "../models/Preset";
 import Player from "../models/Player";
 import {DraftEvent} from "../models/DraftEvent";
 import {IDraftConfig} from "../models/IDraftConfig";
@@ -10,11 +11,11 @@ import {IDraftConfig} from "../models/IDraftConfig";
 export function mapStateToProps({nameHost, nameGuest, whoAmI, preset, nextAction, events}: IStoreState) {
     return {
         events,
-        nameGuest,
-        nameHost,
+        nameGuest: nameGuest as string,
+        nameHost: nameHost as string,
         nextAction,
-        preset,
-        whoAmI
+        preset: preset as Preset,
+        whoAmI: whoAmI as Player,
     }
 }
 

--- a/src/containers/Messages.tsx
+++ b/src/containers/Messages.tsx
@@ -5,7 +5,7 @@ import Messages from "../components/Messages";
 
 export function mapStateToProps(state: IStoreState) {
     let message = 'Finished.';
-    if (state.nextAction < state.preset.turns.length) {
+    if (state.preset && state.nextAction < state.preset.turns.length) {
         const turn = state.preset.turns[state.nextAction];
         message = turn.player.toString() + ': ' + turn.action.toString();
     }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,23 +1,21 @@
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
-// import App from './App';
-import './index.css';
-// import registerServiceWorker from './registerServiceWorker';
 import {applyMiddleware, createStore, Store} from 'redux';
+import {Provider} from 'react-redux';
+import io from 'socket.io-client';
 import {updateState} from './reducers';
 import {IStoreState} from './types';
 import Preset from "./models/Preset";
 import Draft from './containers/Draft';
-import {Provider} from 'react-redux';
-import {default as ModelDraft} from "./models/Draft";
-import * as io from "socket.io-client";
+import ModelDraft from "./models/Draft";
 import {Util} from "./models/Util";
 import {IJoinedMessage} from "./models/IJoinedMessage";
 import Player from "./models/Player";
 import PlayerEvent from "./models/PlayerEvent";
+import {IDraftConfig} from "./models/IDraftConfig";
 import {Action, IActionCompleted, IApplyConfig, IClickOnCiv, ISendJoin, ISetName} from "./actions";
 import {Actions} from "./constants";
-import {IDraftConfig} from "./models/IDraftConfig";
+import './index.css';
 
 const createMySocketMiddleware = () => {
     return (storeAPI: { dispatch: (arg0: Action) => void; }) => {

--- a/src/react-app-env.d.ts
+++ b/src/react-app-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="react-scripts" />

--- a/src/reducers/index.tsx
+++ b/src/reducers/index.tsx
@@ -3,7 +3,19 @@ import {IStoreState} from '../types';
 import Player from "../models/Player";
 import {Actions} from "../constants";
 
-export function updateState(state: IStoreState, action: Action): IStoreState {
+const initialState: IStoreState = {
+    nameHost: undefined,
+    nameGuest: undefined,
+    hostReady: false,
+    guestReady: false,
+    whoAmI: undefined,
+    preset: undefined,
+    nextAction: 0,
+    events: [],
+};
+
+export function updateState(state: IStoreState = initialState, action?: Action): IStoreState {
+    if (!action) return state;
     switch (action.type) {
         case Actions.ACTION_COMPLETED:
             console.log(Actions.ACTION_COMPLETED, state.nextAction + 1);

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,6 +1,6 @@
-import * as express from "express";
+import express from "express";
 import {Server} from "http"
-import * as socketio from "socket.io";
+import socketio from "socket.io";
 import Player from "./models/Player";
 import {IDraftConfig} from "./models/IDraftConfig";
 import {IJoinMessage} from "./models/IJoinMessage";

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -1,4 +1,4 @@
 import * as enzyme from 'enzyme';
-import * as Adapter from 'enzyme-adapter-react-16';
+import Adapter from 'enzyme-adapter-react-16';
 
 enzyme.configure({ adapter: new Adapter() });

--- a/src/types/index.tsx
+++ b/src/types/index.tsx
@@ -2,12 +2,12 @@ import Preset from "../models/Preset";
 import Player from "../models/Player";
 import {DraftEvent} from "../models/DraftEvent";
 export interface IStoreState {
-    nameHost: string;
-    nameGuest: string;
+    nameHost?: string;
+    nameGuest?: string;
     hostReady: boolean;
     guestReady: boolean;
-    whoAmI: Player;
-    preset: Preset;
+    whoAmI?: Player;
+    preset?: Preset;
     nextAction: number;
     events: DraftEvent[];
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,13 +1,15 @@
 {
   "compilerOptions": {
-    "baseUrl": ".",
     "outDir": "build/dist",
     "module": "esnext",
     "target": "es5",
-    "lib": ["es6", "dom"],
+    "lib": [
+      "es6",
+      "dom"
+    ],
     "sourceMap": true,
     "allowJs": true,
-    "jsx": "react",
+    "jsx": "preserve",
     "moduleResolution": "node",
     "rootDir": "src",
     "forceConsistentCasingInFileNames": true,
@@ -17,7 +19,14 @@
     "importHelpers": true,
     "strictNullChecks": true,
     "suppressImplicitAnyIndexErrors": true,
-    "noUnusedLocals": true
+    "noUnusedLocals": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true
   },
   "exclude": [
     "node_modules",
@@ -27,5 +36,8 @@
     "webpack",
     "jest",
     "src/setupTests.ts"
+  ],
+  "include": [
+    "src"
   ]
 }

--- a/tsconfig.prod.json
+++ b/tsconfig.prod.json
@@ -1,3 +1,0 @@
-{
-  "extends": "./tsconfig.json"
-}

--- a/tsconfig.server.json
+++ b/tsconfig.server.json
@@ -1,9 +1,7 @@
 {
   "compilerOptions": {
     "module": "commonjs",
-    "esModuleInterop": false,
     "target": "es6",
-    "noImplicitAny": true,
     "moduleResolution": "node",
     "sourceMap": true,
     "outDir": "build",
@@ -13,7 +11,20 @@
         "node_modules/",
         "src-server/types/*"
       ]
-    }
+    },
+    "noImplicitReturns": true,
+    "noImplicitThis": true,
+    "noImplicitAny": true,
+    "importHelpers": true,
+    "strictNullChecks": true,
+    "suppressImplicitAnyIndexErrors": true,
+    "noUnusedLocals": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true
   },
   "include": [
     "src/server.ts"

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,6 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  "compilerOptions": {
-    "module": "commonjs"
-  }
-}


### PR DESCRIPTION
CRA supports TypeScript since some recent version. Using it instead of react-scripts-ts is probably more future proof because CRA will be maintained for a while :P

CRA's TS config is a bit more strict so this required some changes to make typings work again.

(fwiw, i think it'll be better to move the server side code to a `server/` directory, and keep clientside stuff in `src/`, so they don't interfere. right now CRA is also typechecking the server code)